### PR TITLE
fixed license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Kaderovski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Readme.md
+++ b/Readme.md
@@ -140,5 +140,6 @@ shloader -e "\u2728 all done"
 
 # License
 
-[MIT](https://choosealicense.com/licenses/mit/)
+ - Shloader is under the MIT LICENSE
+ - See [LICENSE](LICENSE)
 


### PR DESCRIPTION
Hello,
I noticed that you incorrectly setup the license for this repo. You need to include the license as part of this repo so that it is included when people clone it. The MIT license also requires a name and year of which were not included as there was not LICENSE file. 

You can merge this pull request or you can make the changes on your own.
